### PR TITLE
Feature/bolt12 client

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -12,8 +12,12 @@ LND_ADDRESS=
 MACAROON_FILE_PATH=
 CERT_FILE_PATH=
 
-# If LN_CLIENT_TYPE is CLN (optional if using LNURL, NWC or LND)
+# If LN_CLIENT_TYPE is CLN (optional if using LNURL, NWC, LND or BOLT12)
 CLN_LIGHTNING_RPC_FILE_PATH=
+
+# If LN_CLIENT_TYPE is BOLT12 (optional if using LNURL, NWC, LND or CLN)
+# Requires CLN_LIGHTNING_RPC_FILE_PATH to be set as well
+BOLT12_LN_OFFER=
 
 # Root key for minting macaroons
 ROOT_KEY=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,6 +123,7 @@ jobs:
 
           docker logs cln
           echo "NWC_URI=$(docker exec cln lightning-cli --network=regtest nip47-create label=nwc-for-l402 budget_msat=0 | jq -r '.uri')" >> $GITHUB_ENV
+          echo "BOLT12_LN_OFFER=$(docker exec cln lightning-cli --network=regtest offer any "BOLT12 Test" | jq -r '.bolt12')" >> $GITHUB_ENV
 
           sudo chmod 777 /cln-socket/lightning-rpc
 
@@ -136,6 +137,20 @@ jobs:
         run: cargo test --verbose --features "no-accept-authenticate-required"
         env: 
           LN_CLIENT_TYPE: CLN
+          CLN_LIGHTNING_RPC_FILE_PATH: /cln-socket/lightning-rpc
+
+      - name: Run tests for BOLT12
+        run: cargo test --verbose
+        env: 
+          LN_CLIENT_TYPE: BOLT12
+          BOLT12_LN_OFFER: ${{ env.BOLT12_LN_OFFER }}
+          CLN_LIGHTNING_RPC_FILE_PATH: /cln-socket/lightning-rpc
+
+      - name: Run tests for BOLT12 for no-accept-authenticate-required feature
+        run: cargo test --verbose --features "no-accept-authenticate-required"
+        env: 
+          LN_CLIENT_TYPE: BOLT12
+          BOLT12_LN_OFFER: ${{ env.BOLT12_LN_OFFER }}
           CLN_LIGHTNING_RPC_FILE_PATH: /cln-socket/lightning-rpc
 
       - name: Run tests for NWC

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # l402_middleware
-A middleware library for rust that uses [L402, formerly known as LSAT](https://github.com/lightninglabs/L402/blob/master/protocol-specification.md) (a protocol standard for authentication and paid APIs) and provides handler functions to accept microtransactions before serving ad-free content or any paid APIs. It supports Lightning Network Daemon (LND), Core Lightning (CLN), Lightning URL (LNURL), and Nostr Wallet Connect (NWC) for generating invoices.
+A middleware library for rust that uses [L402, formerly known as LSAT](https://github.com/lightninglabs/L402/blob/master/protocol-specification.md) (a protocol standard for authentication and paid APIs) and provides handler functions to accept microtransactions before serving ad-free content or any paid APIs. It supports Lightning Network Daemon (LND), Core Lightning (CLN), Lightning URL (LNURL), Nostr Wallet Connect (NWC), and BOLT 12 (Offers) for generating invoices.
 
 Check out the Go version here:
 https://github.com/getAlby/lsat-middleware

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ use std::env;
 use std::sync::Arc;
 use reqwest::Client;
 
-use l402_middleware::{l402, lnclient, lnd, lnurl, nwc, cln, middleware};
+use l402_middleware::{l402, lnclient, lnd, lnurl, nwc, cln, bolt12, middleware};
 
 const SATS_PER_BTC: i64 = 100_000_000;
 const MIN_SATS_TO_BE_PAID: i64 = 1;
@@ -156,6 +156,7 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             }),
             nwc_config: None,
             cln_config: None,
+            bolt12_config: None,
             root_key: env::var("ROOT_KEY")
                 .expect("ROOT_KEY not found in .env")
                 .as_bytes()
@@ -171,6 +172,7 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             lnurl_config: None,
             nwc_config: None,
             cln_config: None,
+            bolt12_config: None,
             root_key: env::var("ROOT_KEY")
                 .expect("ROOT_KEY not found in .env")
                 .as_bytes()
@@ -181,6 +183,7 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             lnd_config: None,
             lnurl_config: None,
             cln_config: None,
+            bolt12_config: None,
             nwc_config: Some(nwc::NWCOptions {
                 uri: env::var("NWC_URI").expect("NWC_URI not found in .env"),
             }),
@@ -194,8 +197,24 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             lnd_config: None,
             lnurl_config: None,
             nwc_config: None,
+            bolt12_config: None,
             cln_config: Some(cln::CLNOptions {
                 lightning_dir: env::var("CLN_LIGHTNING_RPC_FILE_PATH").expect("CLN_LIGHTNING_RPC_FILE_PATH not found in .env"),
+            }),
+            root_key: env::var("ROOT_KEY")
+                .expect("ROOT_KEY not found in .env")
+                .as_bytes()
+                .to_vec(),
+        },
+        "BOLT12" => lnclient::LNClientConfig {
+            ln_client_type,
+            lnd_config: None,
+            lnurl_config: None,
+            nwc_config: None,
+            cln_config: None,
+            bolt12_config: Some(bolt12::Bolt12Options {
+                lightning_dir: env::var("CLN_LIGHTNING_RPC_FILE_PATH").expect("CLN_LIGHTNING_RPC_FILE_PATH not found in .env"),
+                offer: env::var("BOLT12_LN_OFFER").expect("BOLT12_LN_OFFER not found in .env"),
             }),
             root_key: env::var("ROOT_KEY")
                 .expect("ROOT_KEY not found in .env")

--- a/src/bolt12.rs
+++ b/src/bolt12.rs
@@ -1,0 +1,121 @@
+use std::{error::Error, sync::Arc, path::Path};
+use tokio::sync::Mutex;
+use std::future::Future;
+use std::pin::Pin;
+use cln_rpc::ClnRpc;
+use cln_rpc::model::requests::FetchinvoiceRequest;
+use cln_rpc::model::responses::FetchinvoiceResponse;
+use cln_rpc::primitives::Amount;
+use tonic_openssl_lnd::lnrpc;
+
+use crate::lnclient;
+
+#[derive(Debug, Clone)]
+pub struct Bolt12Options {
+    pub lightning_dir: String,
+    pub offer: String,
+}
+
+pub struct Bolt12Wrapper {
+    client: Arc<Mutex<Option<ClnRpc>>>,
+    lightning_dir: String,
+    offer: String,
+}
+
+impl Bolt12Wrapper {
+    pub async fn new_client(
+        ln_client_config: &lnclient::LNClientConfig,
+    ) -> Result<Arc<Mutex<dyn lnclient::LNClient>>, Box<dyn Error + Send + Sync>> {
+        let bolt12_options = ln_client_config.bolt12_config.clone().unwrap();
+
+        println!("BOLT12 client {} with offer {}", bolt12_options.lightning_dir, bolt12_options.offer);
+
+        let wrapper = Bolt12Wrapper {
+            client: Arc::new(Mutex::new(None)),
+            lightning_dir: bolt12_options.lightning_dir,
+            offer: bolt12_options.offer,
+        };
+
+        Ok(Arc::new(Mutex::new(wrapper)))
+    }
+}
+
+impl lnclient::LNClient for Bolt12Wrapper {
+    fn add_invoice(
+        &self,
+        invoice: lnrpc::Invoice,
+    ) -> Pin<Box<dyn Future<Output = Result<lnrpc::AddInvoiceResponse, Box<dyn Error + Send + Sync>>> + Send>> {
+        let client = Arc::clone(&self.client);
+        let lightning_dir = self.lightning_dir.clone();
+        let offer = self.offer.clone();
+        
+        Box::pin(async move {
+            let mut client_guard = client.lock().await;
+            
+            if client_guard.is_none() {
+                // Create the CLN RPC client only when needed
+                let new_client = ClnRpc::new(Path::new(&lightning_dir)).await
+                    .map_err(|e| format!("CLN RPC error: {}", e))?;
+                *client_guard = Some(new_client);
+            }
+            
+            let client = client_guard.as_mut().unwrap();
+            
+            let fetch_invoice_request = FetchinvoiceRequest {
+                offer: offer,
+                amount_msat: Some(Amount::from_msat(invoice.value_msat as u64)),
+                quantity: None,
+                recurrence_counter: None,
+                recurrence_start: None,
+                recurrence_label: None,
+                timeout: None,
+                payer_note: if invoice.memo.is_empty() { None } else { Some(invoice.memo.clone()) },
+                bip353: None,
+                payer_metadata: None,
+            };
+
+            let response: FetchinvoiceResponse = match client.call_typed(&fetch_invoice_request).await {
+                Ok(res) => res,
+                Err(e) => {
+                    // Invalidate client on error to force reconnection next time
+                    *client_guard = None;
+                    return Err(format!("CLN RPC error: {}", e).into());
+                }
+            };
+
+            let invoice_str = response.invoice;
+            
+            // The fetchinvoice RPC returns the BOLT12 invoice string but not the payment hash directly.
+            // We use the `decode` RPC to extract the payment hash from the invoice, which is required for L402.
+            let decode_request = cln_rpc::model::requests::DecodeRequest {
+                string: invoice_str.clone(),
+            };
+            
+            let decode_response: cln_rpc::model::responses::DecodeResponse = match client.call_typed(&decode_request).await {
+                 Ok(res) => res,
+                 Err(e) => {
+                     // Invalidate client on error
+                     *client_guard = None;
+                     return Err(format!("CLN RPC error during decode: {}", e).into());
+                 }
+            };
+                
+            // decode_response should have payment_hash
+            let payment_hash = decode_response.payment_hash.ok_or("No payment hash in decode response")?;
+            let payment_secret = decode_response.payment_secret;
+            
+            Ok(lnrpc::AddInvoiceResponse {
+                r_hash: <cln_rpc::primitives::Sha256 as AsRef<[u8]>>::as_ref(&payment_hash).to_vec(),
+                payment_request: invoice_str,
+                add_index: 0,
+                payment_addr: if let Some(secret) = payment_secret {
+                    // Use unsafe transmute to access bytes since field is private and no accessors exist
+                    // Secret is struct Secret([u8; 32])
+                    unsafe { std::mem::transmute::<_, [u8; 32]>(secret).to_vec() }
+                } else {
+                    vec![]
+                },
+            })
+        })
+    }
+}

--- a/src/bolt12.rs
+++ b/src/bolt12.rs
@@ -16,59 +16,63 @@ pub struct Bolt12Options {
     pub offer: String,
 }
 
-pub struct Bolt12Wrapper {
-    client: Arc<Mutex<Option<ClnRpc>>>,
-    lightning_dir: String,
-    offer: String,
+/// Trait for fetching BOLT12 invoices.
+/// This allows us to swap the backend (CLN, LND, etc.) transparently.
+pub trait Bolt12Backend: Send + Sync {
+    fn fetch_invoice(
+        &self,
+        offer: &str,
+        amount_msat: u64,
+        memo: Option<String>,
+    ) -> Pin<Box<dyn Future<Output = Result<(String, Vec<u8>, Option<Vec<u8>>), Box<dyn Error + Send + Sync>>> + Send>>;
 }
 
-impl Bolt12Wrapper {
-    pub async fn new_client(
-        ln_client_config: &lnclient::LNClientConfig,
-    ) -> Result<Arc<Mutex<dyn lnclient::LNClient>>, Box<dyn Error + Send + Sync>> {
-        let bolt12_options = ln_client_config.bolt12_config.clone().unwrap();
+/// CLN Implementation of Bolt12Backend
+struct ClnBolt12Backend {
+    client: Arc<Mutex<Option<ClnRpc>>>,
+    lightning_dir: String,
+}
 
-        println!("BOLT12 client {} with offer {}", bolt12_options.lightning_dir, bolt12_options.offer);
-
-        let wrapper = Bolt12Wrapper {
+impl ClnBolt12Backend {
+    fn new(lightning_dir: String) -> Self {
+        Self {
             client: Arc::new(Mutex::new(None)),
-            lightning_dir: bolt12_options.lightning_dir,
-            offer: bolt12_options.offer,
-        };
-
-        Ok(Arc::new(Mutex::new(wrapper)))
+            lightning_dir,
+        }
     }
 }
 
-impl lnclient::LNClient for Bolt12Wrapper {
-    fn add_invoice(
+impl Bolt12Backend for ClnBolt12Backend {
+    fn fetch_invoice(
         &self,
-        invoice: lnrpc::Invoice,
-    ) -> Pin<Box<dyn Future<Output = Result<lnrpc::AddInvoiceResponse, Box<dyn Error + Send + Sync>>> + Send>> {
+        offer: &str,
+        amount_msat: u64,
+        memo: Option<String>,
+    ) -> Pin<Box<dyn Future<Output = Result<(String, Vec<u8>, Option<Vec<u8>>), Box<dyn Error + Send + Sync>>> + Send>> {
         let client = Arc::clone(&self.client);
         let lightning_dir = self.lightning_dir.clone();
-        let offer = self.offer.clone();
-        
+        let offer = offer.to_string();
+
         Box::pin(async move {
             let mut client_guard = client.lock().await;
-            
+
             if client_guard.is_none() {
                 let new_client = ClnRpc::new(Path::new(&lightning_dir)).await
                     .map_err(|e| format!("CLN RPC error: {}", e))?;
                 *client_guard = Some(new_client);
             }
-            
+
             let client = client_guard.as_mut().unwrap();
-            
+
             let fetch_invoice_request = FetchinvoiceRequest {
                 offer: offer,
-                amount_msat: Some(Amount::from_msat(invoice.value_msat as u64)),
+                amount_msat: Some(Amount::from_msat(amount_msat)),
                 quantity: None,
                 recurrence_counter: None,
                 recurrence_start: None,
                 recurrence_label: None,
                 timeout: None,
-                payer_note: if invoice.memo.is_empty() { None } else { Some(invoice.memo.clone()) },
+                payer_note: memo,
                 bip353: None,
                 payer_metadata: None,
             };
@@ -82,12 +86,12 @@ impl lnclient::LNClient for Bolt12Wrapper {
             };
 
             let invoice_str = response.invoice;
-            
+
             // Decode to extract payment hash
             let decode_request = cln_rpc::model::requests::DecodeRequest {
                 string: invoice_str.clone(),
             };
-            
+
             let decode_response: cln_rpc::model::responses::DecodeResponse = match client.call_typed(&decode_request).await {
                  Ok(res) => res,
                  Err(e) => {
@@ -95,7 +99,7 @@ impl lnclient::LNClient for Bolt12Wrapper {
                      return Err(format!("CLN RPC error during decode: {}", e).into());
                  }
             };
-                
+
             // BOLT12 invoices return `invoice_payment_hash` (hex) instead of `payment_hash` (Sha256)
             let payment_hash_bytes = if let Some(ph) = decode_response.payment_hash {
                 <cln_rpc::primitives::Sha256 as AsRef<[u8]>>::as_ref(&ph).to_vec()
@@ -105,14 +109,61 @@ impl lnclient::LNClient for Bolt12Wrapper {
                 return Err("No payment hash in decode response".into());
             };
 
-            let payment_secret = decode_response.payment_secret;
+            let payment_secret = decode_response.payment_secret.map(|s| s.to_vec());
+
+            Ok((invoice_str, payment_hash_bytes, payment_secret))
+        })
+    }
+}
+
+pub struct Bolt12Wrapper {
+    backend: Arc<dyn Bolt12Backend>,
+    offer: String,
+}
+
+impl Bolt12Wrapper {
+    pub async fn new_client(
+        ln_client_config: &lnclient::LNClientConfig,
+    ) -> Result<Arc<Mutex<dyn lnclient::LNClient>>, Box<dyn Error + Send + Sync>> {
+        let bolt12_options = ln_client_config.bolt12_config.clone().unwrap();
+
+        println!("BOLT12 client {} with offer {}", bolt12_options.lightning_dir, bolt12_options.offer);
+
+        // In the future, we can check config to decide which backend to instantiate
+        let backend = ClnBolt12Backend::new(bolt12_options.lightning_dir);
+
+        let wrapper = Bolt12Wrapper {
+            backend: Arc::new(backend),
+            offer: bolt12_options.offer,
+        };
+
+        Ok(Arc::new(Mutex::new(wrapper)))
+    }
+}
+
+impl lnclient::LNClient for Bolt12Wrapper {
+    fn add_invoice(
+        &self,
+        invoice: lnrpc::Invoice,
+    ) -> Pin<Box<dyn Future<Output = Result<lnrpc::AddInvoiceResponse, Box<dyn Error + Send + Sync>>> + Send>> {
+        let backend = Arc::clone(&self.backend);
+        let offer = self.offer.clone();
+
+        Box::pin(async move {
+            let memo = if invoice.memo.is_empty() { None } else { Some(invoice.memo.clone()) };
+            
+            let (payment_request, r_hash, payment_secret) = backend.fetch_invoice(
+                &offer, 
+                invoice.value_msat as u64, 
+                memo
+            ).await?;
             
             Ok(lnrpc::AddInvoiceResponse {
-                r_hash: payment_hash_bytes,
-                payment_request: invoice_str,
+                r_hash,
+                payment_request,
                 add_index: 0,
                 payment_addr: if let Some(secret) = payment_secret {
-                    secret.to_vec()
+                    secret
                 } else {
                     vec![]
                 },
@@ -120,3 +171,4 @@ impl lnclient::LNClient for Bolt12Wrapper {
         })
     }
 }
+

--- a/src/bolt12.rs
+++ b/src/bolt12.rs
@@ -112,8 +112,7 @@ impl lnclient::LNClient for Bolt12Wrapper {
                 payment_request: invoice_str,
                 add_index: 0,
                 payment_addr: if let Some(secret) = payment_secret {
-                    // Secret is struct Secret([u8; 32]) - private field access via unsafe
-                    unsafe { std::mem::transmute::<_, [u8; 32]>(secret).to_vec() }
+                    secret.to_vec()
                 } else {
                     vec![]
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod lnd;
 pub mod lnurl;
 pub mod nwc;
 pub mod cln;
+pub mod bolt12;
 pub mod macaroon_util;
 pub mod middleware;
 pub mod utils;

--- a/src/lnclient.rs
+++ b/src/lnclient.rs
@@ -10,11 +10,13 @@ use crate::lnurl;
 use crate::lnd;
 use crate::nwc;
 use crate::cln;
+use crate::bolt12;
 
 const LND_CLIENT_TYPE: &str = "LND";
 const LNURL_CLIENT_TYPE: &str = "LNURL";
 const NWC_CLIENT_TYPE: &str = "NWC";
 const CLN_CLIENT_TYPE: &str = "CLN";
+const BOLT12_CLIENT_TYPE: &str = "BOLT12";
 
 #[derive(Debug, Clone)]
 pub struct LNClientConfig {
@@ -23,6 +25,7 @@ pub struct LNClientConfig {
     pub lnurl_config: Option<lnurl::LNURLOptions>,
     pub nwc_config: Option<nwc::NWCOptions>,
     pub cln_config: Option<cln::CLNOptions>,
+    pub bolt12_config: Option<bolt12::Bolt12Options>,
     pub root_key: Vec<u8>,
 }
 
@@ -44,6 +47,7 @@ impl LNClientConn {
             LNURL_CLIENT_TYPE => lnurl::LnAddressUrlResJson::new_client(ln_client_config).await?,
             NWC_CLIENT_TYPE => nwc::NWCWrapper::new_client(ln_client_config).await?,
             CLN_CLIENT_TYPE => cln::CLNWrapper::new_client(ln_client_config).await?,
+            BOLT12_CLIENT_TYPE => bolt12::Bolt12Wrapper::new_client(ln_client_config).await?,
             _ => {
                 return Err(format!(
                     "LN Client type not recognized: {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::env;
 use std::sync::Arc;
 use reqwest::Client;
 
-use l402_middleware::{l402, lnclient, lnd, lnurl, nwc, cln, middleware};
+use l402_middleware::{l402, lnclient, lnd, lnurl, nwc, cln, bolt12, middleware};
 
 const SATS_PER_BTC: i64 = 100_000_000;
 const MIN_SATS_TO_BE_PAID: i64 = 1;
@@ -114,6 +114,7 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             }),
             nwc_config: None,
             cln_config: None,
+            bolt12_config: None,
             root_key: env::var("ROOT_KEY")
                 .expect("ROOT_KEY not found in .env")
                 .as_bytes()
@@ -129,6 +130,7 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             lnurl_config: None,
             nwc_config: None,
             cln_config: None,
+            bolt12_config: None,
             root_key: env::var("ROOT_KEY")
                 .expect("ROOT_KEY not found in .env")
                 .as_bytes()
@@ -139,6 +141,7 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             lnd_config: None,
             lnurl_config: None,
             cln_config: None,
+            bolt12_config: None,
             nwc_config: Some(nwc::NWCOptions {
                 uri: env::var("NWC_URI").expect("NWC_URI not found in .env"),
             }),
@@ -152,8 +155,24 @@ pub async fn rocket() -> rocket::Rocket<rocket::Build> {
             lnd_config: None,
             lnurl_config: None,
             nwc_config: None,
+            bolt12_config: None,
             cln_config: Some(cln::CLNOptions {
                 lightning_dir: env::var("CLN_LIGHTNING_RPC_FILE_PATH").expect("CLN_LIGHTNING_RPC_FILE_PATH not found in .env"),
+            }),
+            root_key: env::var("ROOT_KEY")
+                .expect("ROOT_KEY not found in .env")
+                .as_bytes()
+                .to_vec(),
+        },
+        "BOLT12" => lnclient::LNClientConfig {
+            ln_client_type,
+            lnd_config: None,
+            lnurl_config: None,
+            nwc_config: None,
+            cln_config: None,
+            bolt12_config: Some(bolt12::Bolt12Options {
+                lightning_dir: env::var("CLN_LIGHTNING_RPC_FILE_PATH").expect("CLN_LIGHTNING_RPC_FILE_PATH not found in .env"),
+                offer: env::var("BOLT12_LN_OFFER").expect("BOLT12_LN_OFFER not found in .env"),
             }),
             root_key: env::var("ROOT_KEY")
                 .expect("ROOT_KEY not found in .env")


### PR DESCRIPTION
## What
This PR implements a BOLT12 client wrapper for Core Lightning, allowing the middleware to generate invoices from a static BOLT12 offer string.

## Why
To support reusable payment endpoints (Offers) as requested in #11. Unlike BOLT11 invoices which are single-use, BOLT12 offers allow the middleware to serve multiple users from a single static configuration (`BOLT12_LN_OFFER`).

## How
- Added `src/bolt12.rs` which implements the `LNClient` trait.
- Uses the `fetchinvoice` RPC to get an invoice for the offer.
- Implements logic to extract the payment hash from the `decode` response (handling `invoice_payment_hash` hex string specific to BOLT12).
- Updated `LNClientConfig` to read `BOLT12_LN_OFFER` from environment variables.

## Testing
- [x] Manually tested with local CLN (Regtest) and Docker
    - Verified `402 Payment Required` response.
    - Verified `L402` header contains valid macaroon and BOLT12 invoice (`lni...`).
    - Confirmed successful invoice decoding and payment hash extraction.

## Checklist
- [x] Code formatted and linted
- [x] No breaking changes (or documented)

Closes #11