### PR TITLE
Fix lnurl allowed comment optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "l402_middleware"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64 0.21.7",
  "bitcoin 0.32.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l402_middleware"
-version = "2.0.0"
+version = "2.1.0"
 description = "A middleware library for rust that provides handler functions to accept microtransactions before serving ad-free content or any paid APIs."
 readme = "README.md"
 documentation = "https://docs.rs/l402_middleware"

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ The middleware:-
 Add the crate to your `Cargo.toml`:
 ```toml
 [dependencies]
-l402_middleware = "2.0.0"
+l402_middleware = "2.1.0"
 ```
 
 By using the no-accept-authenticate-required feature, the check for the Accept-Authenticate header can be bypassed, allowing L402 to be treated as the default authentication option.
 ```toml
 [dependencies]
-l402_middleware = { version = "2.0.0", features = ["no-accept-authenticate-required"] }
+l402_middleware = { version = "2.1.0", features = ["no-accept-authenticate-required"] }
 ```
 
 Ensure that you create a `.env` file based on the provided `.env_example` and configure all the necessary environment variables.

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -28,7 +28,7 @@ pub struct LnAddressUrlResJson {
 
     metadata: String,
 
-    #[serde(rename = "commentAllowed")]
+    #[serde(rename = "commentAllowed", default)]
     comment_allowed: u32,
     tag: String,
 }


### PR DESCRIPTION
Ref: https://github.com/DhananjayPurohit/ngx_l402/issues/69

make `allowedComment` field optional, setting its default value to 0